### PR TITLE
Improve fork codesign responsiveness

### DIFF
--- a/.github/workflows/ci-windows-signed.yml
+++ b/.github/workflows/ci-windows-signed.yml
@@ -250,8 +250,10 @@ jobs:
             -Root 'unsigned' `
             -CertificateThumbprint $thumb `
             -MaxFiles ([int]$env:MAX_SIGN_FILES) `
-            -TimeoutSeconds ([int]$env:TS_TIMEOUT_SEC) `
+            -PerFileTimeoutSeconds ([int]$env:TS_TIMEOUT_SEC) `
             -Mode 'fork' `
+            -SkipAlreadySigned `
+            -VerboseEvery 25 `
             -SummaryPath $env:GITHUB_STEP_SUMMARY
 
       - name: Sign scripts (Authenticode) - upstream (timestamp + timeout + fallback)


### PR DESCRIPTION
## Summary
- add progress logging, skip-already-signed logic, and per-file timeout controls to Invoke-ScriptSigningBatch.ps1
- update ci-windows-signed.yaml fork-safe step to use those options so the codesign-dev job no longer appears stalled

## Testing
- pwsh -NoLogo -NoProfile -File tools/Invoke-ScriptSigningBatch.ps1 -Root temp-sign-scripts -CertificateThumbprint <test-thumb> -Mode test-run