### PR TITLE
Use dedicated token for handshake watchdog

### DIFF
--- a/.github/workflows/handshake-watchdog.yml
+++ b/.github/workflows/handshake-watchdog.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Fetch latest handshake pointer artifact
         id: fetch-pointer
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WATCHDOG_GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p pointer-artifact
           repo="${GITHUB_REPOSITORY}"


### PR DESCRIPTION
## Summary
- handshake-watchdog now uses `WATCHDOG_GH_TOKEN` (falls back to `GITHUB_TOKEN` if not set) when calling `gh api` so listing/downloading artifacts no longer 404s

## Testing
- n/a (workflow change only; relies on secret presence)