### PR TITLE
Trim base64 before decoding signing PFX

### DIFF
--- a/.github/workflows/ci-windows-signed.yml
+++ b/.github/workflows/ci-windows-signed.yml
@@ -364,7 +364,14 @@ jobs:
       - name: Decode PFX (temp file)
         if: ${{ steps.determine_signing_mode_prod.outputs.has_prod_cert == 'true' }}
         run: |
-          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\\codesign.pfx", [Convert]::FromBase64String('${{ secrets.WIN_CODESIGN_PFX_B64 }}'))
+          $pfxRaw = @'
+${{ secrets.WIN_CODESIGN_PFX_B64 }}
+'@
+          $pfxClean = ($pfxRaw -replace '\s','')
+          if ([string]::IsNullOrWhiteSpace($pfxClean)) {
+            throw "WIN_CODESIGN_PFX_B64 secret resolved to an empty string."
+          }
+          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\\codesign.pfx", [Convert]::FromBase64String($pfxClean))
 
       - name: Sign binaries (signtool)
         if: ${{ steps.determine_signing_mode_prod.outputs.has_prod_cert == 'true' }}


### PR DESCRIPTION
## Summary
- the codesign-dev job now strips whitespace from `WIN_CODESIGN_PFX_B64` before calling `Convert.FromBase64String`, preventing decode errors when secrets contain newlines.

## Testing
- n/a: workflow-only change.