### PR TITLE
Enable dispatch for ci-windows-signed

### DIFF
--- a/.github/workflows/ci-windows-signed.yml
+++ b/.github/workflows/ci-windows-signed.yml
@@ -1,6 +1,7 @@
 name: ci-windows-signed
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [develop]


### PR DESCRIPTION
## Summary
- allow ci-windows-signed to be triggered through workflow_dispatch (useful for reruns)

## Testing
- n/a (workflow-only change)