### PR TITLE
Add dispatch + fix PFX decoding

### DIFF
--- a/.github/workflows/ci-windows-signed.yml
+++ b/.github/workflows/ci-windows-signed.yml
@@ -221,7 +221,14 @@ jobs:
       - name: Decode PFX (temp file)
         if: ${{ steps.determine_signing_mode.outputs.has_prod_cert == 'true' }}
         run: |
-          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\\codesign.pfx", [Convert]::FromBase64String('${{ secrets.WIN_CODESIGN_PFX_B64 }}'))
+          $pfxRaw = @'
+            ${{ secrets.WIN_CODESIGN_PFX_B64 }}
+          '@
+          $pfxClean = ($pfxRaw -replace '\s','')
+          if ([string]::IsNullOrWhiteSpace($pfxClean)) {
+            throw "WIN_CODESIGN_PFX_B64 secret resolved to an empty string."
+          }
+          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\\codesign.pfx", [Convert]::FromBase64String($pfxClean))
 
       - name: Sign binaries (signtool)
         if: ${{ steps.determine_signing_mode.outputs.has_prod_cert == 'true' }}
@@ -372,8 +379,8 @@ jobs:
         if: ${{ steps.determine_signing_mode_prod.outputs.has_prod_cert == 'true' }}
         run: |
           $pfxRaw = @'
-${{ secrets.WIN_CODESIGN_PFX_B64 }}
-'@
+            ${{ secrets.WIN_CODESIGN_PFX_B64 }}
+          '@
           $pfxClean = ($pfxRaw -replace '\s','')
           if ([string]::IsNullOrWhiteSpace($pfxClean)) {
             throw "WIN_CODESIGN_PFX_B64 secret resolved to an empty string."
@@ -483,3 +490,4 @@ ${{ secrets.WIN_CODESIGN_PFX_B64 }}
       - name: Cleanup PFX
         if: always()
         run: Remove-Item "$env:RUNNER_TEMP\\codesign.pfx" -Force -ErrorAction SilentlyContinue
+


### PR DESCRIPTION
## Summary\n- add workflow_dispatch trigger with optional reason input to ci-windows-signed\n- trim base64 PFX secrets in both codesign-dev and codesign-prod before decoding\n\n## Testing\n- ran actionlint